### PR TITLE
fix(reducer): set default to action argument

### DIFF
--- a/source/reducer.js
+++ b/source/reducer.js
@@ -18,7 +18,7 @@ const initialState = fromJS({
 
 const pathToArr = path => path.split(/\//).filter(p => !!p)
 
-export default (state = initialState, action) => {
+export default (state = initialState, action = {}) => {
   const {path} = action
   let pathArr
   let retVal


### PR DESCRIPTION
Hello @prescottprue 
I add default value to action argument
It will prevent `const { path } = action` from failure
Thanks for reviewing my PR
and also great thanks for forking the v3 project
