### PR TITLE
Add initial load watcher

### DIFF
--- a/source/actions.js
+++ b/source/actions.js
@@ -6,7 +6,9 @@ import {
     LOGOUT,
     LOGIN_ERROR,
     NO_VALUE,
-    INIT_BY_PATH
+    INIT_BY_PATH,
+  AUTHENTICATION_STARTED,
+  AUTHENTICATION_FINISHED
 } from './constants'
 
 import { Promise } from 'es6-promise'
@@ -271,6 +273,8 @@ export const login = (dispatch, firebase, credentials) => {
 }
 
 export const init = (dispatch, firebase) => {
+  dispatch({ type: AUTHENTICATION_STARTED })
+
   firebase.auth().onAuthStateChanged(authData => {
     if (!authData) {
       return dispatch({type: LOGOUT})
@@ -281,6 +285,8 @@ export const init = (dispatch, firebase) => {
 
     dispatchLogin(dispatch, authData)
   })
+
+  dispatch({ type: AUTHENTICATION_FINISHED })
 
   firebase.auth().currentUser
 }

--- a/source/compose.js
+++ b/source/compose.js
@@ -15,7 +15,9 @@ export default (config) => {
 
     try {
       Firebase.initializeApp(config)
-    } catch (err) {}
+    } catch (err) {
+      console.warn('Firebase error:', err)
+    }
 
     const ref = Firebase.database().ref()
 

--- a/source/constants.js
+++ b/source/constants.js
@@ -8,6 +8,8 @@ module.exports = {
   LOGIN: `${prefix}LOGIN`,
   LOGOUT: `${prefix}LOGOUT`,
   LOGIN_ERROR: `${prefix}LOGIN_ERROR`,
+  AUTHENTICATION_STARTED: `${prefix}AUTHENTICATION_STARTED`,
+  AUTHENTICATION_FINISHED: `${prefix}AUTHENTICATION_FINISHED`,
   NO_VALUE: `${prefix}NO_VALUE`,
   INIT_BY_PATH: `${prefix}INIT_BY_PATH`
 }

--- a/source/reducer.js
+++ b/source/reducer.js
@@ -7,6 +7,8 @@ import {
   LOGOUT,
   LOGIN_ERROR,
   NO_VALUE,
+  AUTHENTICATION_STARTED,
+  AUTHENTICATION_FINISHED,
   INIT_BY_PATH
 } from './constants'
 
@@ -14,6 +16,7 @@ const initialState = fromJS({
   auth: undefined,
   authError: undefined,
   profile: undefined,
+  isLoading: false,
   data: {},
   snapshot: {}
 })
@@ -103,6 +106,12 @@ export default (state = initialState, action = {}) => {
       return (profile !== undefined)
         ? state.setIn(['profile'], fromJS(profile))
         : state.deleteIn(['profile'])
+
+    case AUTHENTICATION_STARTED:
+      return state.set('isLoading', true)
+
+    case AUTHENTICATION_FINISHED:
+      return state.set('isLoading', false)
 
     case LOGOUT:
       return fromJS({


### PR DESCRIPTION
I set this up because I was running into an edge error where my app couldn't tell if we were waiting for auth data, so sometimes assumed that it wasn't authenticated.  This sets an isLoading state and then changes it when user authentication returns.
